### PR TITLE
Remove EOL OSes from build and add new versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
   matrix:
   - OS=el DIST=6
   - OS=el DIST=7
-  - OS=fedora DIST=27
-  - OS=fedora DIST=26
+  - OS=fedora DIST=29
+  - OS=fedora DIST=28
   - OS=Windows VISUAL_STUDIO="Visual Studio 15 2017" JANSSON_LIB="jansson.lib" ARCH=x86
   - OS=Windows VISUAL_STUDIO="Visual Studio 15 2017 Win64" JANSSON_LIB="janssonx64.lib" ARCH=x64
 matrix:
@@ -23,9 +23,9 @@ matrix:
   - os: windows
     env: OS=el DIST=7
   - os: windows
-    env: OS=fedora DIST=27
+    env: OS=fedora DIST=29
   - os: windows
-    env: OS=fedora DIST=26
+    env: OS=fedora DIST=28
   - os: linux
     env: OS=Windows VISUAL_STUDIO="Visual Studio 15 2017" JANSSON_LIB="jansson.lib" ARCH=x86
   - os: linux


### PR DESCRIPTION
Fedora 26 & 27 are EOL. This replaces them in the build with Fedora 28 & 29 which are currently supported.