### PR TITLE
Add getArraySize() to keep json_t abstracted under redfishPayload

### DIFF
--- a/include/redfishPayload.h
+++ b/include/redfishPayload.h
@@ -214,6 +214,15 @@ REDFISH_EXPORT redfishPayload* getPayloadForPathString(redfishPayload* payload, 
  */
 REDFISH_EXPORT size_t          getCollectionSize(redfishPayload* payload);
 /**
+ * @brief Obtain the number of members of an array
+ *
+ * Return the number of elements in the array.
+ *
+ * @param payload The payload to get number of elements in
+ * @return 0 if the payload is not an array. The total number of elements in the array otherwise.
+ */
+REDFISH_EXPORT size_t          getArraySize(redfishPayload* payload);
+/**
  * @brief Set json element by name from json_t
  *
  * Set a json element from a json element

--- a/src/payload.c
+++ b/src/payload.c
@@ -506,6 +506,15 @@ size_t getCollectionSize(redfishPayload* payload)
     return (size_t)json_integer_value(count);
 }
 
+size_t getArraySize(redfishPayload *payload)
+{
+    if(!payload || !json_is_array(payload->json))
+    {
+        return 0;
+    }
+    return json_array_size(payload->json);
+}
+
 bool setPayloadElementByName(redfishPayload* payload, const char* name, json_t* element)
 {
     int rc;


### PR DESCRIPTION
We're writing a C++ wrapper library which uses libredfish. We want the wrapper library to only be interacting with libredfish and not need to break abstraction layers and touch json_t methods for the sole purpose of handling arrays.