### PR TITLE
Add getPayloadBoolValue to redfishPayload.h

### DIFF
--- a/include/redfishPayload.h
+++ b/include/redfishPayload.h
@@ -152,6 +152,17 @@ REDFISH_EXPORT char*           getPayloadStringValue(redfishPayload* payload);
  * @return int contained in the payload or 0 if not a string entity
  */
 REDFISH_EXPORT int             getPayloadIntValue(redfishPayload* payload);
+/**
+ * @brief Get the boolean value for the payload
+ *
+ * If the value of the payload is not a boolean, is_boolean will be set to false and the return value should be considered invalid. Otherwise return
+ * the boolean contained in the payload.
+ *
+ * @param payload The payload to get the bool value of
+ * @param is_boolean Pointer whose value will be set to true if the value of the payload is a boolean
+ * @return bool contained in the payload
+ */
+REDFISH_EXPORT bool            getPayloadBoolValue(redfishPayload* payload, bool* is_boolean);
 
 /**
  * @brief Obtain the node in the payload identified by the specified nodeName

--- a/src/payload.c
+++ b/src/payload.c
@@ -262,6 +262,13 @@ int getPayloadIntValue(redfishPayload* payload)
     return (int)json_integer_value(payload->json);
 }
 
+bool getPayloadBoolValue(redfishPayload* payload, bool* is_boolean) {
+  if (is_boolean != NULL) {
+    *is_boolean = json_is_boolean(payload->json);
+  }
+  return json_boolean_value(payload->json);
+}
+
 redfishPayload* getPayloadByNodeName(redfishPayload* payload, const char* nodeName)
 {
     json_t* value;


### PR DESCRIPTION
There is a consistent interface for getPayloadStringValue and
getPayloadIntValue, but there is not yet one for bool values.