### PR TITLE
Add getPayloadDoubleValue to redfishPayload.h

### DIFF
--- a/include/redfishPayload.h
+++ b/include/redfishPayload.h
@@ -163,6 +163,17 @@ REDFISH_EXPORT int             getPayloadIntValue(redfishPayload* payload);
  * @return bool contained in the payload
  */
 REDFISH_EXPORT bool            getPayloadBoolValue(redfishPayload* payload, bool* is_boolean);
+/**
+ * @brief Get the double value for the payload
+ *
+ * If the value of the payload is not a double, *is_double will be set to false and the return value should be considered invalid. Otherwise return
+ * the double contained in the payload.
+ *
+ * @param payload The payload to get the double value of
+ * @param is_double Pointer whose value will be set to true if the value of the payload is a double
+ * @return double contained in the payload
+ */
+REDFISH_EXPORT double          getPayloadDoubleValue(redfishPayload* payload, bool* is_double);
 
 /**
  * @brief Obtain the node in the payload identified by the specified nodeName

--- a/src/payload.c
+++ b/src/payload.c
@@ -269,6 +269,14 @@ bool getPayloadBoolValue(redfishPayload* payload, bool* is_boolean) {
   return json_boolean_value(payload->json);
 }
 
+double getPayloadDoubleValue(redfishPayload* payload, bool* is_double) {
+    if (is_double != NULL)
+    {
+      *is_double = json_is_real(payload->json);
+    }
+    return json_real_value(payload->json);
+}
+
 redfishPayload* getPayloadByNodeName(redfishPayload* payload, const char* nodeName)
 {
     json_t* value;


### PR DESCRIPTION
We added getPayloadBoolValue earlier as well. The purpose of these
getter functions is to have libredfish continue to abstract the jansson
library for its users.