### PR TITLE
Support unix domain sockets via 'unix://' in hostname

### DIFF
--- a/include/redfishService.h
+++ b/include/redfishService.h
@@ -140,10 +140,14 @@ typedef void (*redfishEventCallback)(redfishPayload* event, enumeratorAuthentica
  * HTTPS           | IPv4               | https://127.0.0.1
  * HTTP            | IPv6               | http://[::1]
  * HTTPS           | IPv6               | https://[::1]
+ * UDS             | Unix Filepath      | unix:///var/run/my.socket
  *
- * @param host The host to connect to. This must contain the protocol schema see above for more details.
- * @param rootUri The root URI of the redfish service. If NULL the connection with assume /redfish
- * @param auth The authentication method to use for the redfish service. If NULL the connection will be made with no authentication
+ * @param host The host to connect to. This must contain the protocol schema see
+ * above for more details.
+ * @param rootUri The root URI of the redfish service. If NULL the connection
+ * with assume /redfish
+ * @param auth The authentication method to use for the redfish service. If NULL
+ * the connection will be made with no authentication
  * @param flags Any extra flags to pass to the service
  * @return A new redfish service structure representing the connection.
  * @see serviceDecRef
@@ -386,10 +390,14 @@ typedef void (*redfishCreateAsyncCallback)(redfishService* service, void* contex
  * HTTPS           | IPv4               | https://127.0.0.1
  * HTTP            | IPv6               | http://[::1]
  * HTTPS           | IPv6               | https://[::1]
+ * UDS             | Unix Filepath      | unix:///var/run/my.socket
  *
- * @param host The host to connect to. This must contain the protocol schema see above for more details.
- * @param rootUri The root URI of the redfish service. If NULL the connection with assume /redfish
- * @param auth The authentication method to use for the redfish service. If NULL the connection will be made with no authentication
+ * @param host The host to connect to. This must contain the protocol schema see
+ * above for more details.
+ * @param rootUri The root URI of the redfish service. If NULL the connection
+ * with assume /redfish
+ * @param auth The authentication method to use for the redfish service. If NULL
+ * the connection will be made with no authentication
  * @param flags Any extra flags to pass to the service
  * @param callback The callback to call when the service is created
  * @param context The context to pass to the callback

--- a/src/asyncRaw.c
+++ b/src/asyncRaw.c
@@ -270,11 +270,12 @@ threadRet rawAsyncWorkThread(void* data)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readChunk);
     curl_easy_setopt(curl, CURLOPT_READDATA, &writeChunk);
 
+#ifndef _MSC_VER
     if (service->unix_domain_socket) {
       curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH,
                        service->unix_domain_socket);
     }
-
+#endif
     while(queuePop(q, (void**)&workItem) == 0)
     {
         if(workItem->term)

--- a/src/asyncRaw.c
+++ b/src/asyncRaw.c
@@ -270,6 +270,11 @@ threadRet rawAsyncWorkThread(void* data)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readChunk);
     curl_easy_setopt(curl, CURLOPT_READDATA, &writeChunk);
 
+    if (service->unix_domain_socket) {
+      curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH,
+                       service->unix_domain_socket);
+    }
+
     while(queuePop(q, (void**)&workItem) == 0)
     {
         if(workItem->term)

--- a/src/internal_service.h
+++ b/src/internal_service.h
@@ -32,6 +32,8 @@
 typedef struct _redfishService {
     /** The host, including protocol schema **/
     char* host;
+    /** The unix domain socket path if applicable, NULL otherwise **/
+    char* unix_domain_socket;
     /** The queue of asynchronous HTTP(s) requests **/
     queue* queue;
     /** The thread running asynchronous HTTP(s) requests **/

--- a/src/internal_service.h
+++ b/src/internal_service.h
@@ -32,8 +32,10 @@
 typedef struct _redfishService {
     /** The host, including protocol schema **/
     char* host;
+#ifndef _MSC_VER
     /** The unix domain socket path if applicable, NULL otherwise **/
     char* unix_domain_socket;
+#endif
     /** The queue of asynchronous HTTP(s) requests **/
     queue* queue;
     /** The thread running asynchronous HTTP(s) requests **/

--- a/src/service.c
+++ b/src/service.c
@@ -1119,7 +1119,10 @@ static void freeServicePtr(redfishService* service)
     terminateAsyncThread(service);
     free(service->host);
     service->host = NULL;
+#ifndef _MSC_VER
     free(service->unix_domain_socket);
+    service->unix_domain_socket = NULL;
+#endif
     json_decref(service->versions);
     service->versions = NULL;
     if(service->sessionToken != NULL)


### PR DESCRIPTION
We were wondering if there was any interest in supporting unix domain sockets in libredfish.

For velocity's sake, we are just hackishly treating a hostname with "uds://" prepended as a unix domain socket path. This has been working so far, but we're open to suggestions on how you might want this to look nicer in the library.