### PR TITLE
Add missing json_incref to payload.c

### DIFF
--- a/src/payload.c
+++ b/src/payload.c
@@ -861,6 +861,7 @@ bool getPayloadByIndexAsync(redfishPayload* payload, size_t index, redfishAsyncO
         free(uri);
         return ret;
     }
+    json_incref(value);
     retPayload = createRedfishPayload(value, payload->service);
     callback(true, 200, retPayload, context);
     return true;


### PR DESCRIPTION
Without this json_incref, the returned redfishPayload does not own the
json ptr and risks holding a dangling ptr if the original redfishPayload
is cleaned up.