### PR TITLE
Fix-Cmake: installation of entities public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,17 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-set(REDFISH_HDR_PUBLIC 
+set(REDFISH_HDR_PUBLIC_RED 
    ${CMAKE_CURRENT_SOURCE_DIR}/include/redfish.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/redfishEvent.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/redfishPayload.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/redfishRawAsync.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/redfishService.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/redpath.h)
+
+set(REDFISH_HDR_PUBLIC_ENTITIES 
+   ${CMAKE_CURRENT_SOURCE_DIR}/include/entities/chassis.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/include/entities/resource.h)
 
 file(GLOB REDFISH_SRC src/*.c src/entities/*.c)
 
@@ -90,7 +94,8 @@ endif()
 install(TARGETS redfishtest redfish
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib)
-install(FILES ${REDFISH_HDR_PUBLIC} DESTINATION include)
+install(FILES ${REDFISH_HDR_PUBLIC_RED} DESTINATION include)
+install(FILES ${REDFISH_HDR_PUBLIC_ENTITIES} DESTINATION include/entities)
 
 ENABLE_TESTING()
 


### PR DESCRIPTION
(Hereinbelow comment associated with tests on RHEL8.3 OS)

The installation of libredfish did not copy two headers required/included by
redfish.h, namely `entities/chassis.h` and `entities/resource.h`.
As a result, it was impossible to compile C code with a dependency on
libredfish.

The proposed fix is quick and simple, not to say quick and dirty.
A list of public headers to install was created specifically for the
entities subfolder (named `REDFISH_HDR_PUBLIC_ENTITIES`).
For consistency, the initial list of public header, namely `REDFISH_HDR_PUBLIC`,
was renamed `REDFISH_HDR_PUBLIC_RED` (since the names of all the header belonging
to it are prefixed by "red").