### PR TITLE
Fix-Cmake: missing dependency at link edition for redfishcli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ add_executable(redfishcli "${CMAKE_CURRENT_SOURCE_DIR}/examples/cli.c")
 target_link_libraries(redfishcli redfish jansson)
 if(READLINE_FOUND)
     add_definitions(-DHAVE_READLINE)
-    target_link_libraries(redfishcli ${Readline_LIBRARY})
+    target_link_libraries(redfishcli ${Readline_LIBRARY} ${Tinfo_LIBRARY})
 endif()
 
 add_executable(destorytest "${CMAKE_CURRENT_SOURCE_DIR}/examples/destroy.c")

--- a/FindReadline.cmake
+++ b/FindReadline.cmake
@@ -33,17 +33,25 @@ find_library(Readline_LIBRARY
     HINTS ${Readline_ROOT_DIR}/lib
 )
 
-if(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
-  set(READLINE_FOUND TRUE)
-else(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
-  FIND_LIBRARY(Readline_LIBRARY NAMES readline)
-  include(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Readline DEFAULT_MSG Readline_INCLUDE_DIR Readline_LIBRARY )
-  MARK_AS_ADVANCED(Readline_INCLUDE_DIR Readline_LIBRARY)
-endif(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+find_library(Tinfo_LIBRARY
+    NAMES libtinfo libtinfo.so libtinfo.so.6 libtinfo.so.6.1
+)
+
+if(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Tinfo_LIBRARY)
+    set(READLINE_FOUND TRUE)
+else(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Tinfo_LIBRARY)
+    find_library(Readline_LIBRARY NAMES readline)
+    find_library(Tinfo_LIBRARY NAMES tinfo tinfo.so tinfo.so.6 tinfo.so.6.1)
+    include(FindPackageHandleStandardArgs)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(Readline
+        DEFAULT_MSG Readline_INCLUDE_DIR Readline_LIBRARY
+    )
+    MARK_AS_ADVANCED(Readline_INCLUDE_DIR Readline_LIBRARY Tinfo_LIBRARY)
+endif(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Tinfo_LIBRARY)
 
 mark_as_advanced(
     Readline_ROOT_DIR
     Readline_INCLUDE_DIR
     Readline_LIBRARY
+    Tinfo_LIBRARY
 )


### PR DESCRIPTION
(Hereinbelow comment associated with tests on RHEL8.3)

On RHEL8, the `readline-devel` RPM is not available (even when EPEL8 is taken
into account).
As a result, it is compulsory to compile and install `readline` from source.

At compile time (i.e while running `make` after the `Makefile` was generated
through the action of `cmake`), it appears that some symbols used by
`libreadline` are not defined:

``` bash
/usr/local/lib/libreadline.so: undefined reference to 'tgetstr'
/usr/local/lib/libreadline.so: undefined reference to 'tputs'
/usr/local/lib/libreadline.so: undefined reference to 'BC'
/usr/local/lib/libreadline.so: undefined reference to 'tgetent'
/usr/local/lib/libreadline.so: undefined reference to 'tgetflag'
/usr/local/lib/libreadline.so: undefined reference to 'tgoto'
/usr/local/lib/libreadline.so: undefined reference to 'UP'
/usr/local/lib/libreadline.so: undefined reference to 'tgetnum'
/usr/local/lib/libreadline.so: undefined reference to 'PC'
```

Those symbols are defined by `libtinfo`, which can be installed from the official
RHEL8 repositories.
As a result, to be able to build `redfishcli`, which depends on `libreadline`, it
seems that it is required to also link on `libtinfo`.

To do so, `FindReadline.cmake` was modified so as to look for the path to
`libtinfo`, and return it into `${Tinfo_LIBRARY}`.
`CMakeLists.txt` was then modified to link to `${Tinfo_LIBRARY}` when building
`redfishcli`.